### PR TITLE
Add complete compose config

### DIFF
--- a/compose/full.yml
+++ b/compose/full.yml
@@ -1,5 +1,47 @@
 # compose/full.yml
 services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: notion
+      POSTGRES_PASSWORD: notion
+      POSTGRES_DB: notion
+    ports:
+      - "5433:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+      - ../db:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "notion"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  api:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: stage0-api
+    environment:
+      DATABASE_URL: postgresql+asyncpg://notion:notion@db:5432/notion
+      REDIS_URL: redis://redis:6379/0
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
   crdt:
     build:
       context: ..
@@ -8,6 +50,12 @@ services:
     ports:
       - "50051:50051"
     depends_on:
-      - api
-      - db
-      - redis
+      api:
+        condition: service_started
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- fill out `compose/full.yml`
- add db, redis and api services similar to spine-only compose file
- add volumes section
- ensure `crdt` depends on api, db, and redis services

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684236d4d8fc832790b41e686ffec25d