### PR TITLE
Add .env.example and mention in setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment configuration
+# Copy this file to `.env` and adjust values as needed
+
+# PostgreSQL connection string used by the FastAPI service
+DATABASE_URL=postgresql+asyncpg://notion:notion@localhost:5433/notion
+
+# Redis connection URL
+REDIS_URL=redis://localhost:6379/0
+
+# gRPC address for the Automerge CRDT service
+CRDT_GRPC_ADDR=localhost:50051

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ This repo is the **Stage 0 “Garage Prototype”** of the Notion Data-Spine pro
 
 ## Getting Started
 
-1. Copy `.env.example` → `.env` and fill in keys  
+1. Copy `.env.example` → `.env` and fill in keys. The sample values
+   mirror the Docker Compose services (Postgres on `5433`, Redis on
+   `6379`, CRDT gRPC on `50051`).
 2. `docker compose -f compose/spine-only.yml up --build -d`  
 3. `pytest` passes on your local  
 


### PR DESCRIPTION
## Summary
- add an example environment file with defaults
- mention example env variables in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684239ac447c8327962b5f3742f91f78