### PR TITLE
Add extra unit tests

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,25 @@
+import pytest
+import fakeredis.aioredis
+
+from app.cache import cache_get, cache_set
+
+
+@pytest.fixture(autouse=True)
+async def fake_redis(monkeypatch):
+    redis = fakeredis.aioredis.FakeRedis()
+
+    async def _get_redis():
+        return redis
+
+    monkeypatch.setattr("app.cache.get_redis", _get_redis)
+    yield redis
+
+
+@pytest.mark.asyncio
+async def test_cache_roundtrip():
+    await cache_set("foo", {"bar": 1})
+    assert await cache_get("foo") == {"bar": 1}
+
+    # delete using ttl=0
+    await cache_set("foo", None, ttl=0)
+    assert await cache_get("foo") is None

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,14 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import create_app
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint():
+    app = create_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- test the async Redis cache with fakeredis
- add a health endpoint test

## Testing
- `pytest -q` *(fails: OperationalError connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684264e6b70c832782b3c238b4f819f5