### PR TITLE
Fix Kafka startup and search-worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ Requires **Python&nbsp;3.12** with [Poetry](https://python-poetry.org/).
    to start the full Docker Compose stack.
    If Kafka or Zookeeper fail to start, run
    `docker compose -f compose/full.yml down -v` to clear old volumes.
+   The search-worker relies on `PYTHONPATH` being `/home/appuser/code`; this is
+   set in the Compose file.
    The API container now seeds the database automatically on first start
    using `scripts/seed_then_start.sh`.
-4. `pytest`
+4. `poetry run pytest`
 
 Optionally run `poetry run pre-commit run --all-files` to lint and format
 the codebase.

--- a/compose/full.yml
+++ b/compose/full.yml
@@ -86,6 +86,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       MEILI_URL: http://meili:7700
       MEILI_MASTER_KEY: masterKey
+      PYTHONPATH: /home/appuser/code
     depends_on:
       kafka:
         condition: service_started

--- a/src/app/ws.py
+++ b/src/app/ws.py
@@ -56,6 +56,7 @@ async def start_kafka_consumer() -> None:
     try:
         await consumer.start()
     except KafkaError:
+        await consumer.stop()
         return
     try:
         async for msg in consumer:


### PR DESCRIPTION
## Summary
- fix websocket Kafka consumer cleanup
- set PYTHONPATH for search-worker service
- document troubleshooting steps for full compose stack

## Testing
- `poetry run pre-commit run --files src/app/ws.py compose/full.yml README.md`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887a354ded883279608ea8fd6e70f5d