### PR TITLE
Fix CI wait for API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,17 @@ jobs:
       - name: Start services
         run: docker compose -f compose/${{ matrix.profile }}.yml up -d
 
+      - name: Wait for API
+        run: |
+          for i in {1..60}; do
+            if curl -fsS http://localhost:8000/health >/dev/null; then
+              echo "API is up" && break
+            fi
+            echo "Waiting for API..."
+            sleep 1
+          done
+          curl -fsS http://localhost:8000/health
+
       - name: Run tests
         env:
           PYTHONPATH: ${{ github.workspace }}


### PR DESCRIPTION
## Summary
- wait for the FastAPI container to respond before running tests

## Testing
- `poetry run pytest`
- `poetry run pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_688928c78cd48327af76dfb37c389b89